### PR TITLE
fix: delete survey data

### DIFF
--- a/app/composables/project/model/project-data.ts
+++ b/app/composables/project/model/project-data.ts
@@ -8,6 +8,7 @@ export interface ProjectData<D extends (string | ProjectDataFeature) = (string |
   syncAt?: number
   tags?: string[]
   participantLocation?: [number, number]
+  version?: number
 }
 
 export interface ProjectDataImage {

--- a/app/service/api/project/index.ts
+++ b/app/service/api/project/index.ts
@@ -307,8 +307,13 @@ async function uploadImageNeedSync(projectId: string, chunkedCount: number = 3, 
   return rows
 }
 
+interface DeletedKey {
+  id: string
+  version?: number
+}
+
 export interface SyncProjectDataPayload {
-  deletedKeys: Record<string, string>[] | []
+  deletedKeys: DeletedKey[] | []
   modified: ProjectDataUpdatePayload[]
   projectVersionId: string
 }
@@ -326,7 +331,7 @@ async function countImageNeedSync(projectId: string) {
 }
 
 export interface SyncProjectDataPayload {
-  deletedKeys: Record<string, string>[] | []
+  deletedKeys: DeletedKey[] | []
   modified: ProjectDataUpdatePayload[]
   projectVersionId: string
 }
@@ -340,31 +345,33 @@ async function sendSyncRequest(projectId: string, payload: SyncProjectDataPayloa
           id: UUID.parse(row.id).bytes,
         })),
         deletedKeys: payload.deletedKeys.map((row) => ({
-          id: row.id ? UUID.parse(row.id).bytes : [],
+          id: UUID.parse(row.id).bytes,
+          version: row.version,
         })),
         projectVersionId: payload.projectVersionId,
       })
 
-      await useMainServiceFetch(`/projects/${projectId}/data/sync`, {
+      const result = await useMainServiceFetch(`/projects/${projectId}/data/sync`, {
         method: "POST",
         body: msgPackBody,
         headers: {
           "Content-Type": "application/msgpack",
         },
       })
-      return // Exit if MessagePack succeeds
+      return result.data // Exit if MessagePack succeeds
     }
     catch (e) {
       // eslint-disable-next-line no-console
       console.debug(`Failed to send MessagePack, falling back to JSON: ${get(e, "message")}`)
     }
   }
-
   // Fallback to JSON if MessagePack fails or is not requested
-  await useMainServiceFetch(`/projects/${projectId}/data/sync`, {
+  const result = await useMainServiceFetch(`/projects/${projectId}/data/sync`, {
     method: "POST",
     body: payload,
   })
+
+  return result.data
 }
 
 async function syncProjectData(projectId: string, msgPack?: boolean) {
@@ -465,14 +472,19 @@ async function syncProjectDataUpdate(projectId: string, chunkedCount?: number, p
       projectVersionId: project.versionId,
     } satisfies SyncProjectDataPayload
 
-    await sendSyncRequest(projectId, payload, true)
+    const result = await sendSyncRequest(projectId, payload, true) as [string, number][]
 
     currentChunk += 1
 
     const db = useDb()
+
     try {
       await db.transaction("rw", db.projectData, async (tx) => {
         await tx.projectData.where("id").anyOf(modifiedDataId).modify({ syncAt })
+
+        for (const [id, version] of result) {
+          await tx.projectData.where("id").equals(id).modify({ version })
+        }
       })
     }
     catch (e) {
@@ -480,7 +492,6 @@ async function syncProjectDataUpdate(projectId: string, chunkedCount?: number, p
       console.debug("ignoring update error status because data already sent")
       captureToCloud(e)
     }
-
     try {
       await db.transaction("rw", db.changesHistory, async (tx) => {
         await tx.changesHistory.where("id").anyOf(modifiedRowId).delete()
@@ -510,7 +521,6 @@ async function syncProjectDataDeleted(projectId: string, msgPack?: boolean) {
   if (project?.versionId == null) {
     throw new Error("need to sync")
   }
-
   const rows = await useDb().changesHistory.filter((row) => row.projectId === projectId && row.changeType === TableChangeType.Delete).toArray()
   if (rows.length === 0) {
     return
@@ -520,6 +530,7 @@ async function syncProjectDataDeleted(projectId: string, msgPack?: boolean) {
     modified: [],
     deletedKeys: rows.map((row) => ({
       id: row.dataId,
+      version: row.version,
     })),
     projectVersionId: project.versionId,
   } satisfies SyncProjectDataPayload

--- a/app/service/api/project/index.ts
+++ b/app/service/api/project/index.ts
@@ -308,7 +308,7 @@ async function uploadImageNeedSync(projectId: string, chunkedCount: number = 3, 
 }
 
 export interface SyncProjectDataPayload {
-  deletedKeys: string[]
+  deletedKeys: Record<string, string>[] | []
   modified: ProjectDataUpdatePayload[]
   projectVersionId: string
 }
@@ -326,7 +326,7 @@ async function countImageNeedSync(projectId: string) {
 }
 
 export interface SyncProjectDataPayload {
-  deletedKeys: string[]
+  deletedKeys: Record<string, string>[] | []
   modified: ProjectDataUpdatePayload[]
   projectVersionId: string
 }
@@ -339,7 +339,9 @@ async function sendSyncRequest(projectId: string, payload: SyncProjectDataPayloa
           ...row,
           id: UUID.parse(row.id).bytes,
         })),
-        deletedKeys: payload.deletedKeys.map((row) => UUID.parse(row).bytes),
+        deletedKeys: payload.deletedKeys.map((row) => ({
+          id: row.id ? UUID.parse(row.id).bytes : [],
+        })),
         projectVersionId: payload.projectVersionId,
       })
 
@@ -395,7 +397,7 @@ async function syncProjectData(projectId: string, msgPack?: boolean) {
 
   const payload = {
     modified: rows,
-    deletedKeys,
+    deletedKeys: deletedKeys.map((id) => ({ id })),
     projectVersionId: project.versionId,
   }
   await sendSyncRequest(projectId, payload, msgPack)
@@ -516,7 +518,9 @@ async function syncProjectDataDeleted(projectId: string, msgPack?: boolean) {
 
   const payload = {
     modified: [],
-    deletedKeys: rows.map((row) => row.dataId),
+    deletedKeys: rows.map((row) => ({
+      id: row.dataId,
+    })),
     projectVersionId: project.versionId,
   } satisfies SyncProjectDataPayload
 

--- a/app/service/api/project/index.ts
+++ b/app/service/api/project/index.ts
@@ -443,7 +443,6 @@ async function syncProjectDataUpdate(projectId: string, chunkedCount?: number, p
     return
   }
 
-  const modifiedDataId = modified.map((row) => row.dataId)
   const modifiedRowId = modified.map((row) => row.id)
 
   const projectDataStore = useProjectData(projectId)
@@ -480,10 +479,8 @@ async function syncProjectDataUpdate(projectId: string, chunkedCount?: number, p
 
     try {
       await db.transaction("rw", db.projectData, async (tx) => {
-        await tx.projectData.where("id").anyOf(modifiedDataId).modify({ syncAt })
-
         for (const [id, version] of result) {
-          await tx.projectData.where("id").equals(id).modify({ version })
+          await tx.projectData.where("id").equals(id).modify({ syncAt, version })
         }
       })
     }


### PR DESCRIPTION
**This PR includes:**
1. Fix for bug in deleting survey data.

**Issues Found:**
1. 
- Problem: The version field does not exist in the projectData and changeHistory tables in IndexedDB.
- Solution: Added a new version column to both projectData and changeHistory tables to align with backend requirements, particularly for handling data deletion.

2. 
- Problem: There was no logic to store the version value after a successful data submission.
- Solution: Updated the sync logic to store the version value into the projectData table in IndexedDB after each successful submission, ensuring that future deletions can reference the correct version.